### PR TITLE
Add support Redis 4.x

### DIFF
--- a/mario-redis-lock.gemspec
+++ b/mario-redis-lock.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'redis', '~> 3', '>= 3.0.5' # Needed support for SET with EX, PX, NX, XX options: https://github.com/redis/redis-rb/pull/343
+  spec.add_runtime_dependency 'redis', '>= 3.0.5', '< 5' # Needed support for SET with EX, PX, NX, XX options: https://github.com/redis/redis-rb/pull/343
 
   spec.add_development_dependency 'bundler', '~> 1'
   spec.add_development_dependency 'rake', '~> 10'


### PR DESCRIPTION
> - Removed `Redis.connect`. Use `Redis.new`.
> - Removed `Redis#[]` and `Redis#[]=` aliases.
> - Added support for `CLIENT` commands. The lower-level client can be accessed via `Redis#_client`.
> - Dropped official support for Ruby < 2.2.2.

cite: https://github.com/redis/redis-rb/blob/v4.0.1/CHANGELOG.md#40

In Redis v4, methods which are not used in some mario-redis-lock have been deleted. Support Ruby for < v2.2.2 was lost.

