### PR TITLE
Fix install error

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
+require "redis_lock"
 
 Rake::TestTask.new do |t|
   t.pattern = "spec/**/*_spec.rb"

--- a/lib/redis_lock.rb
+++ b/lib/redis_lock.rb
@@ -1,10 +1,8 @@
 require 'redis' # redis gem required
 require 'securerandom' # SecureRandom (from stdlib)
+require 'redis_lock/version'
 
 class RedisLock
-
-  # Gem version
-  VERSION = "1.2.0"
 
   # Original defaults
   DEFAULT_ATTRS = {

--- a/lib/redis_lock/version.rb
+++ b/lib/redis_lock/version.rb
@@ -1,0 +1,5 @@
+class RedisLock
+
+  # Gem version
+  VERSION = "1.2.0"
+end

--- a/mario-redis-lock.gemspec
+++ b/mario-redis-lock.gemspec
@@ -2,7 +2,7 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require 'redis_lock'
+require 'redis_lock/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "mario-redis-lock"


### PR DESCRIPTION
```console
$ bundle

[!] There was an error parsing `Gemfile`: 
[!] There was an error while loading `mario-redis-lock.gemspec`: cannot load such file -- redis
Does it try to require a relative path? That's been removed in Ruby 1.9. Bundler cannot continue.

 #  from /Users/ykzts/works/ykzts/mario-redis-lock/mario-redis-lock.gemspec:5
 #  -------------------------------------------
 #  
 >  require 'redis_lock'
 #  
 #  -------------------------------------------
. Bundler cannot continue.

 #  from /Users/ykzts/works/ykzts/mario-redis-lock/Gemfile:4
 #  -------------------------------------------
 #  # Specify your gem's dependencies in mario-redis-lock.gemspec
 >  gemspec
 #  -------------------------------------------
```

😖